### PR TITLE
Add support for Mirth versions >= 3.12

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ func (e *Exporter) LoadChannelIdNameMap() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
 
 	// This one line implements the authentication required for the task.
 	req.SetBasicAuth(e.mirthUsername, e.mirthPassword)
@@ -194,6 +195,7 @@ func (e *Exporter) HitMirthRestApisAndUpdateMetrics(channelIdNameMap map[string]
 	if err != nil {
 		log.Fatal(err)
 	}
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
 
 	// This one line implements the authentication required for the task.
 	req.SetBasicAuth(e.mirthUsername, e.mirthPassword)

--- a/main.go
+++ b/main.go
@@ -156,6 +156,8 @@ func (e *Exporter) LoadChannelIdNameMap() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Mirth versions >= 3.12 require the X-Requested-With header
 	req.Header.Add("X-Requested-With", "XMLHttpRequest")
 
 	// This one line implements the authentication required for the task.
@@ -195,6 +197,8 @@ func (e *Exporter) HitMirthRestApisAndUpdateMetrics(channelIdNameMap map[string]
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Mirth versions >= 3.12 require the X-Requested-With header
 	req.Header.Add("X-Requested-With", "XMLHttpRequest")
 
 	// This one line implements the authentication required for the task.


### PR DESCRIPTION
The X-Requested-With header is required for Mirth API calls in versions of mirth >= 3.12. 

Adding this header is backward compatible with previous Mirth versions so there shouldn't be any compatibility issues.