### PR TITLE
[OBSERVE-14] Add QUEUED count to channel metrics

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:alpine
+
+WORKDIR /app
+
+# Download necessary Go modules
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy files and build
+COPY *.go .
+RUN go build -o /mirth_channel_exporter
+
+# Runtime
+EXPOSE 8080
+CMD [ "/mirth_channel_exporter" ]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,42 @@ To run it:
 | mirth_messages_sent_total  | How many messages have been sent | channel |
 | mirth_messages_errored_total  | How many messages have errored | channel |
 
+```
+# HELP mirth_channel_status 
+# TYPE mirth_channel_status gauge
+mirth_channel_status{channel="foo", status="STARTED"} 1
+mirth_channel_status{channel="bar", status="PAUSED"} 1
+
+# HELP mirth_messages_errored_total How many messages have errored (per channel).
+# TYPE mirth_messages_errored_total gauge
+mirth_messages_errored_total{channel="foo"} 0
+mirth_messages_errored_total{channel="bar"} 2
+
+# HELP mirth_messages_filtered_total How many messages have been filtered (per channel).
+# TYPE mirth_messages_filtered_total gauge
+mirth_messages_filtered_total{channel="foo"} 0
+mirth_messages_filtered_total{channel="bar"} 193
+
+# HELP mirth_messages_queued How many messages are currently queued (per channel).
+# TYPE mirth_messages_queued gauge
+mirth_messages_queued{channel="foo"} 0
+mirth_messages_queued{channel="bar"} 0
+
+# HELP mirth_messages_received_total How many messages have been received (per channel).
+# TYPE mirth_messages_received_total gauge
+mirth_messages_received_total{channel="foo"} 6.3965406e+07
+mirth_messages_received_total{channel="bar"} 387
+
+# HELP mirth_messages_sent_total How many messages have been sent (per channel).
+# TYPE mirth_messages_sent_total gauge
+mirth_messages_sent_total{channel="foo"} 1.21855264e+08
+mirth_messages_sent_total{channel="bar"} 964
+
+# HELP mirth_up Was the last Mirth query successful.
+# TYPE mirth_up gauge
+mirth_up 1
+```
+
 ## Flags
     ./mirth_channel_exporter --help
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ To run it:
     go build
     ./mirth_channel_exporter [flags]
 
+or via Docker compose:
+```yaml
+services:
+  mirth_exporter:
+    image: ghcr.io/waytohealth/mirth_channel_exporter:latest
+    restart: always
+    ports:
+      - "9141:9141"
+    environment:
+      - MIRTH_ENDPOINT=${mirth_url}
+      - MIRTH_USERNAME=${mirth_username}
+      - MIRTH_PASSWORD=${mirth_password}
+```
+
 ## Exported Metrics
 | Metric | Description | Labels |
 | ------ | ------- | ------ |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ services:
 | mirth_messages_queued | How many messages are currently queued | channel |
 | mirth_messages_sent_total  | How many messages have been sent | channel |
 | mirth_messages_errored_total  | How many messages have errored | channel |
+| mirth_undeployed_revisions  |  How many channel revisions have not been deployed | channel | 
 
 ```
 # HELP mirth_channel_status
@@ -79,6 +80,10 @@ mirth_messages_sent_total{channel="bar"} 964
 # HELP mirth_up Was the last Mirth query successful.
 # TYPE mirth_up gauge
 mirth_up 1
+
+# HELP mirth_undeployed_revisions channel.DeployedRevisionDelta of all deployed channels
+# TYPE mirth_undeployed_revisions gauge
+mirth_undeployed_revisions{channel="foo"} 13
 ```
 
 ## Flags

--- a/README.md
+++ b/README.md
@@ -25,17 +25,18 @@ services:
 ```
 
 ## Exported Metrics
-| Metric | Description | Labels |
-| ------ | ------- | ------ |
-| mirth_up | Was the last Mirth CLI query successful | |
-| mirth_request_duration | Histogram for the runtime of the metric pull from Mirth | |
-| mirth_channel_status | Status of all deployed channels | channel, status |
-| mirth_messages_received_total | How many messages have been received | channel |
-| mirth_messages_filtered_total  | How many messages have been filtered | channel |
-| mirth_messages_queued | How many messages are currently queued | channel |
-| mirth_messages_sent_total  | How many messages have been sent | channel |
-| mirth_messages_errored_total  | How many messages have errored | channel |
-| mirth_undeployed_revisions  |  How many channel revisions have not been deployed | channel | 
+| Metric                        | Description                                             | Labels          |
+|-------------------------------|---------------------------------------------------------|-----------------|
+| mirth_up                      | Was the last Mirth CLI query successful                 |                 |
+| mirth_info                    | Version information                                     | version         |
+| mirth_request_duration        | Histogram for the runtime of the metric pull from Mirth |                 |
+| mirth_channel_status          | Status of all deployed channels                         | channel, status |
+| mirth_messages_received_total | How many messages have been received                    | channel         |
+| mirth_messages_filtered_total | How many messages have been filtered                    | channel         |
+| mirth_messages_queued         | How many messages are currently queued                  | channel         |
+| mirth_messages_sent_total     | How many messages have been sent                        | channel         |
+| mirth_messages_errored_total  | How many messages have errored                          | channel         |
+| mirth_undeployed_revisions    | How many channel revisions have not been deployed       | channel         | 
 
 ```
 # HELP mirth_channel_status
@@ -80,6 +81,10 @@ mirth_messages_sent_total{channel="bar"} 964
 # HELP mirth_up Was the last Mirth query successful.
 # TYPE mirth_up gauge
 mirth_up 1
+
+# HELP mirth_info Version information about this Mirth instance.
+# TYPE mirth_info gauge
+mirth_info{version="3.8.1"} 1
 
 # HELP mirth_undeployed_revisions channel.DeployedRevisionDelta of all deployed channels
 # TYPE mirth_undeployed_revisions gauge

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 Export [Mirth Connect](https://en.wikipedia.org/wiki/Mirth_Connect) channel
 statistics to [Prometheus](https://prometheus.io).
 
-Metrics are retrieved using the Mirth Connect REST API. This has only been tested
-with Mirth Connect 3.7.1, and it should work with version after 3.7.1.
+Metrics are retrieved using the Mirth Connect REST API. This was tested in versions 3.7.1 and newer. It is generally expected to work in any MC release 3.4.0 and greater but has not been explicitly tested in all releases. Test cases are welcome.
 
 To run it:
 
@@ -15,6 +14,8 @@ To run it:
 | Metric | Description | Labels |
 | ------ | ------- | ------ |
 | mirth_up | Was the last Mirth CLI query successful | |
+| mirth_request_duration | Histogram for the runtime of the metric pull from Mirth | |
+| mirth_channel_status | Status of all deployed channels | channel, status |
 | mirth_messages_received_total | How many messages have been received | channel |
 | mirth_messages_filtered_total  | How many messages have been filtered | channel |
 | mirth_messages_queued | How many messages are currently queued | channel |
@@ -22,10 +23,19 @@ To run it:
 | mirth_messages_errored_total  | How many messages have errored | channel |
 
 ```
-# HELP mirth_channel_status 
+# HELP mirth_channel_status
 # TYPE mirth_channel_status gauge
 mirth_channel_status{channel="foo", status="STARTED"} 1
 mirth_channel_status{channel="bar", status="PAUSED"} 1
+
+# HELP mirth_request_duration Histogram for the runtime of the metric pull from Mirth.
+# TYPE mirth_request_duration histogram
+mirth_request_duration_bucket{le="0.1"} 0
+mirth_request_duration_bucket{le="0.2"} 0
+mirth_request_duration_bucket{le="0.30000000000000004"} 1
+...
+mirth_request_duration_bucket{le="2.0000000000000004"} 5
+mirth_request_duration_bucket{le="+Inf"} 5
 
 # HELP mirth_messages_errored_total How many messages have errored (per channel).
 # TYPE mirth_messages_errored_total gauge

--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<-
 
 	for _, channel := range channelStatusMap.Channels {
 		ch <- prometheus.MustNewConstMetric(
-			channelStatuses, prometheus.UntypedValue, 1, channel.Name, channel.State,
+			channelStatuses, prometheus.GaugeValue, 1, channel.Name, channel.State,
 		)
 
 		for _, entry := range channel.CurrentStatistics {

--- a/main.go
+++ b/main.go
@@ -24,12 +24,8 @@ type ChannelStatus struct {
 	State              string                         `xml:"state"`
 	CurrentStatistics  []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
 	LifetimeStatistics []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
-}
 
-type ChannelStatusStatistics struct {
-	Entries []ChannelStatusStatisticsEntry `xml:"entry"`
 	/*
-		The stats returned from status API
 		   <statistics class="linked-hash-map">
 			  <entry>
 				<com.mirth.connect.donkey.model.message.Status>RECEIVED</com.mirth.connect.donkey.model.message.Status>

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<-
 			metric := pickMetric(entry.Status)
 			if metric != nil {
 				ch <- prometheus.MustNewConstMetric(
-					metric, prometheus.CounterValue, entry.MessageCount, channel.Name,
+					metric, prometheus.GaugeValue, entry.MessageCount, channel.Name,
 				)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -1,222 +1,21 @@
 package main
 
 import (
-	"crypto/tls"
-	"encoding/xml"
 	"flag"
 	"github.com/joho/godotenv"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 )
 
-type ChannelStatusMap struct {
-	XMLName  xml.Name        `xml:"list"`
-	Channels []ChannelStatus `xml:"dashboardStatus"`
-}
-type ChannelStatus struct {
-	XMLName            xml.Name                       `xml:"dashboardStatus"`
-	ChannelId          string                         `xml:"channelId"`
-	Name               string                         `xml:"name"`
-	State              string                         `xml:"state"`
-	CurrentStatistics  []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
-	LifetimeStatistics []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
-
-	/*
-		<statistics class="linked-hash-map">
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>RECEIVED</com.mirth.connect.donkey.model.message.Status>
-			<long>70681</long>
-		  </entry>
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>FILTERED</com.mirth.connect.donkey.model.message.Status>
-			<long>0</long>
-		  </entry>
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>SENT</com.mirth.connect.donkey.model.message.Status>
-			<long>67139</long>
-		  </entry>
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>ERROR</com.mirth.connect.donkey.model.message.Status>
-			<long>3542</long>
-		  </entry>
-		</statistics>
-	*/
-}
-
-type ChannelStatusStatisticsEntry struct {
-	Status       string  `xml:"com.mirth.connect.donkey.model.message.Status"`
-	MessageCount float64 `xml:"long"`
-}
-
-const namespace = "mirth"
-const channelStatusesApi = "/api/channels/statuses"
-
 var (
-	tr = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client = &http.Client{Transport: tr}
-
 	listenAddress = flag.String("web.listen-address", ":9141",
 		"Address to listen on for telemetry")
 	metricsPath = flag.String("web.telemetry-path", "/metrics",
 		"Path under which to expose metrics")
-
-	// Metrics
-	up = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "up"),
-		"Was the last Mirth query successful.",
-		nil, nil,
-	)
-	channelStatuses = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "channel_status"),
-		"Status of all deployed channels",
-		[]string{"channel", "status"}, nil,
-	)
-	messagesReceived = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_received_total"),
-		"How many messages have been received (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesFiltered = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_filtered_total"),
-		"How many messages have been filtered (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesQueued = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_queued"),
-		"How many messages are currently queued (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesSent = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_sent_total"),
-		"How many messages have been sent (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesErrored = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_errored_total"),
-		"How many messages have errored (per channel).",
-		[]string{"channel"}, nil,
-	)
-	requestDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    prometheus.BuildFQName(namespace, "", "request_duration"),
-		Help:    "Histogram for the runtime of the metric pull from Mirth.",
-		Buckets: prometheus.LinearBuckets(0.1, 0.1, 20),
-	})
 )
-
-type Exporter struct {
-	mirthEndpoint, mirthUsername, mirthPassword string
-}
-
-func NewExporter(mirthEndpoint string, mirthUsername string, mirthPassword string) *Exporter {
-	return &Exporter{
-		mirthEndpoint: mirthEndpoint,
-		mirthUsername: mirthUsername,
-		mirthPassword: mirthPassword,
-	}
-}
-
-func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- up
-	ch <- channelStatuses
-	ch <- messagesReceived
-	ch <- messagesFiltered
-	ch <- messagesQueued
-	ch <- messagesSent
-	ch <- messagesErrored
-}
-
-func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-	channelIdStatusMap, err := e.LoadChannelStatuses()
-	if err != nil {
-		ch <- prometheus.MustNewConstMetric(
-			up, prometheus.GaugeValue, 0,
-		)
-		log.Println(err)
-		return
-	}
-	ch <- prometheus.MustNewConstMetric(
-		up, prometheus.GaugeValue, 1,
-	)
-
-	e.AssembleMetrics(channelIdStatusMap, ch)
-}
-
-func (e *Exporter) LoadChannelStatuses() (*ChannelStatusMap, error) {
-	timer := prometheus.NewTimer(requestDuration)
-	defer timer.ObserveDuration()
-	req, err := http.NewRequest("GET", e.mirthEndpoint+channelStatusesApi, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// This one line implements the authentication required for the task.
-	req.SetBasicAuth(e.mirthUsername, e.mirthPassword)
-	// Make request and show output.
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	// fmt.Println(string(body))
-
-	// initialize map variable
-	var channelStatusMap ChannelStatusMap
-	// unmarshal body byteArray into the ChannelStatusMap struct
-	err = xml.Unmarshal(body, &channelStatusMap)
-	if err != nil {
-		return nil, err
-	}
-
-	return &channelStatusMap, nil
-}
-
-func pickMetric(status string) *prometheus.Desc {
-	switch status {
-	case "RECEIVED":
-		return messagesReceived
-	case "FILTERED":
-		return messagesFiltered
-	case "SENT":
-		return messagesSent
-	case "QUEUED":
-		return messagesQueued
-	case "ERROR":
-		return messagesErrored
-	}
-	return nil
-}
-
-func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<- prometheus.Metric) {
-	ch <- requestDuration
-
-	for _, channel := range channelStatusMap.Channels {
-		ch <- prometheus.MustNewConstMetric(
-			channelStatuses, prometheus.GaugeValue, 1, channel.Name, channel.State,
-		)
-
-		for _, entry := range channel.CurrentStatistics {
-			metric := pickMetric(entry.Status)
-			if metric != nil {
-				ch <- prometheus.MustNewConstMetric(
-					metric, prometheus.GaugeValue, entry.MessageCount, channel.Name,
-				)
-			}
-		}
-	}
-
-	log.Println("Endpoint scraped")
-}
 
 func main() {
 	err := godotenv.Load()
@@ -230,8 +29,9 @@ func main() {
 	mirthUsername := os.Getenv("MIRTH_USERNAME")
 	mirthPassword := os.Getenv("MIRTH_PASSWORD")
 
-	exporter := NewExporter(mirthEndpoint, mirthUsername, mirthPassword)
-	prometheus.MustRegister(exporter)
+	prometheus.MustRegister(
+		NewExporter(mirthEndpoint, mirthUsername, mirthPassword),
+	)
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/metrics.go
+++ b/metrics.go
@@ -82,6 +82,7 @@ func (e *Exporter) LoadChannelStatuses() (*ChannelStatusMap, error) {
 		return nil, err
 	}
 
+	req.Header.Add("X-Requested-With", "mirth_channel_exporter")
 	// This one line implements the authentication required for the task.
 	req.SetBasicAuth(e.mirthUsername, e.mirthPassword)
 	// Make request and show output.

--- a/metrics.go
+++ b/metrics.go
@@ -31,6 +31,12 @@ var (
 		[]string{"channel", "status"}, nil,
 	)
 
+	channelDeployedRevisionDeltas = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "channel_deployed_revision_delta"),
+		"channel.DeployedRevisionDelta of all deployed channels",
+		[]string{"channel"}, nil,
+	)
+
 	messagesReceived = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "messages_received_total"),
 		"How many messages have been received (per channel).",
@@ -124,6 +130,10 @@ func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<-
 	for _, channel := range channelStatusMap.Channels {
 		ch <- prometheus.MustNewConstMetric(
 			channelStatuses, prometheus.GaugeValue, 1, channel.Name, channel.State,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			channelDeployedRevisionDeltas, prometheus.GaugeValue, channel.DeployedRevisionDelta, channel.Name,
 		)
 
 		for _, entry := range channel.CurrentStatistics {

--- a/metrics.go
+++ b/metrics.go
@@ -32,7 +32,7 @@ var (
 	)
 
 	channelDeployedRevisionDeltas = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "channel_deployed_revision_delta"),
+		prometheus.BuildFQName(namespace, "", "channel_undeployed_revisions"),
 		"channel.DeployedRevisionDelta of all deployed channels",
 		[]string{"channel"}, nil,
 	)

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/xml"
+	"github.com/prometheus/client_golang/prometheus"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+const namespace = "mirth"
+const channelStatusesApi = "/api/channels/statuses"
+
+var (
+	tr = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client = &http.Client{Transport: tr}
+
+	up = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "up"),
+		"Was the last Mirth query successful.",
+		nil, nil,
+	)
+
+	channelStatuses = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "channel_status"),
+		"Status of all deployed channels",
+		[]string{"channel", "status"}, nil,
+	)
+
+	messagesReceived = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_received_total"),
+		"How many messages have been received (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesFiltered = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_filtered_total"),
+		"How many messages have been filtered (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesQueued = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_queued"),
+		"How many messages are currently queued (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesSent = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_sent_total"),
+		"How many messages have been sent (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesErrored = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_errored_total"),
+		"How many messages have errored (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	requestDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    prometheus.BuildFQName(namespace, "", "request_duration"),
+		Help:    "Histogram for the runtime of the metric pull from Mirth.",
+		Buckets: prometheus.LinearBuckets(0.1, 0.1, 20),
+	})
+)
+
+func (e *Exporter) LoadChannelStatuses() (*ChannelStatusMap, error) {
+	timer := prometheus.NewTimer(requestDuration)
+	defer timer.ObserveDuration()
+	req, err := http.NewRequest("GET", e.mirthEndpoint+channelStatusesApi, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// This one line implements the authentication required for the task.
+	req.SetBasicAuth(e.mirthUsername, e.mirthPassword)
+	// Make request and show output.
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	// fmt.Println(string(body))
+
+	// initialize map variable
+	var channelStatusMap ChannelStatusMap
+	// unmarshal body byteArray into the ChannelStatusMap struct
+	err = xml.Unmarshal(body, &channelStatusMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return &channelStatusMap, nil
+}
+
+func pickMetric(status string) *prometheus.Desc {
+	switch status {
+	case "RECEIVED":
+		return messagesReceived
+	case "FILTERED":
+		return messagesFiltered
+	case "SENT":
+		return messagesSent
+	case "QUEUED":
+		return messagesQueued
+	case "ERROR":
+		return messagesErrored
+	}
+	return nil
+}
+
+func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<- prometheus.Metric) {
+	ch <- requestDuration
+
+	for _, channel := range channelStatusMap.Channels {
+		ch <- prometheus.MustNewConstMetric(
+			channelStatuses, prometheus.GaugeValue, 1, channel.Name, channel.State,
+		)
+
+		for _, entry := range channel.CurrentStatistics {
+			metric := pickMetric(entry.Status)
+			if metric != nil {
+				ch <- prometheus.MustNewConstMetric(
+					metric, prometheus.GaugeValue, entry.MessageCount, channel.Name,
+				)
+			}
+		}
+	}
+
+	log.Println("Endpoint scraped")
+}
+
+type Exporter struct {
+	mirthEndpoint, mirthUsername, mirthPassword string
+}
+
+func NewExporter(mirthEndpoint string, mirthUsername string, mirthPassword string) *Exporter {
+	return &Exporter{
+		mirthEndpoint: mirthEndpoint,
+		mirthUsername: mirthUsername,
+		mirthPassword: mirthPassword,
+	}
+}
+
+func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- up
+	ch <- channelStatuses
+	ch <- messagesReceived
+	ch <- messagesFiltered
+	ch <- messagesQueued
+	ch <- messagesSent
+	ch <- messagesErrored
+}
+
+func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+	channelIdStatusMap, err := e.LoadChannelStatuses()
+	if err != nil {
+		ch <- prometheus.MustNewConstMetric(
+			up, prometheus.GaugeValue, 0,
+		)
+		log.Println(err)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+		up, prometheus.GaugeValue, 1,
+	)
+
+	e.AssembleMetrics(channelIdStatusMap, ch)
+}

--- a/metrics.go
+++ b/metrics.go
@@ -32,7 +32,7 @@ var (
 	)
 
 	channelDeployedRevisionDeltas = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "channel_undeployed_revisions"),
+		prometheus.BuildFQName(namespace, "", "undeployed_revisions"),
 		"channel.DeployedRevisionDelta of all deployed channels",
 		[]string{"channel"}, nil,
 	)

--- a/types.go
+++ b/types.go
@@ -2,6 +2,33 @@ package main
 
 import "encoding/xml"
 
+type ChannelStatistics struct {
+	XMLName   xml.Name `xml:"channelStatistics"`
+	ServerId  string   `xml:"ServerId"`
+	ChannelId string   `xml:"channelId"`
+	Received  float64  `xml:"received"`
+	Sent      float64  `xml:"sent"`
+	Error     float64  `xml:"error"`
+	Queued    float64  `xml:"queued"`
+}
+
+/*
+  <channelStatistics>
+    <serverId>6d555cac-1671-481f-abae-7e1e791eb2d5</serverId>
+    <channelId>d7ecfa9c-4f73-4280-b8bc-ced3a154b1ea</channelId>
+    <received>39</received>
+    <sent>39</sent>
+    <error>0</error>
+    <filtered>0</filtered>
+    <queued>0</queued>
+  </channelStatistics>
+*/
+
+type ChannelStatisticsMap struct {
+	XMLName  xml.Name            `xml:"list"`
+	Channels []ChannelStatistics `xml:"channelStatistics"`
+}
+
 type ChannelStatus struct {
 	XMLName               xml.Name                       `xml:"dashboardStatus"`
 	ChannelId             string                         `xml:"channelId"`

--- a/types.go
+++ b/types.go
@@ -3,12 +3,13 @@ package main
 import "encoding/xml"
 
 type ChannelStatus struct {
-	XMLName            xml.Name                       `xml:"dashboardStatus"`
-	ChannelId          string                         `xml:"channelId"`
-	Name               string                         `xml:"name"`
-	State              string                         `xml:"state"`
-	CurrentStatistics  []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
-	LifetimeStatistics []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
+	XMLName               xml.Name                       `xml:"dashboardStatus"`
+	ChannelId             string                         `xml:"channelId"`
+	Name                  string                         `xml:"name"`
+	State                 string                         `xml:"state"`
+	DeployedRevisionDelta float64                        `xml:"deployedRevisionDelta"`
+	CurrentStatistics     []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
+	LifetimeStatistics    []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
 
 	/*
 		<statistics class="linked-hash-map">
@@ -41,4 +42,3 @@ type ChannelStatusStatisticsEntry struct {
 	Status       string  `xml:"com.mirth.connect.donkey.model.message.Status"`
 	MessageCount float64 `xml:"long"`
 }
-

--- a/types.go
+++ b/types.go
@@ -1,0 +1,44 @@
+package main
+
+import "encoding/xml"
+
+type ChannelStatus struct {
+	XMLName            xml.Name                       `xml:"dashboardStatus"`
+	ChannelId          string                         `xml:"channelId"`
+	Name               string                         `xml:"name"`
+	State              string                         `xml:"state"`
+	CurrentStatistics  []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
+	LifetimeStatistics []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
+
+	/*
+		<statistics class="linked-hash-map">
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>RECEIVED</com.mirth.connect.donkey.model.message.Status>
+			<long>70681</long>
+		  </entry>
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>FILTERED</com.mirth.connect.donkey.model.message.Status>
+			<long>0</long>
+		  </entry>
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>SENT</com.mirth.connect.donkey.model.message.Status>
+			<long>67139</long>
+		  </entry>
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>ERROR</com.mirth.connect.donkey.model.message.Status>
+			<long>3542</long>
+		  </entry>
+		</statistics>
+	*/
+}
+
+type ChannelStatusMap struct {
+	XMLName  xml.Name        `xml:"list"`
+	Channels []ChannelStatus `xml:"dashboardStatus"`
+}
+
+type ChannelStatusStatisticsEntry struct {
+	Status       string  `xml:"com.mirth.connect.donkey.model.message.Status"`
+	MessageCount float64 `xml:"long"`
+}
+


### PR DESCRIPTION
The exporter calls /api/channels/statuses which does NOT include QUEUED counts.  /api/channels/statistics does include QUEUED count.   In order to get QUEUED counts included in the exporter metrics, a second call to /api/channels/statistics is made.